### PR TITLE
Fixed Code typo from mae_3 to mse_3 in Section : COMPARING RESULTS

### DIFF
--- a/01_neural_network_regression_in_tensorflow.ipynb
+++ b/01_neural_network_regression_in_tensorflow.ipynb
@@ -2777,7 +2777,7 @@
       "source": [
         "model_results = [[\"model_1\", mae_1, mse_1],\n",
         "                 [\"model_2\", mae_2, mse_2],\n",
-        "                 [\"model_3\", mae_3, mae_3]]"
+        "                 [\"model_3\", mae_3, mse_3]]"
       ],
       "execution_count": null,
       "outputs": []


### PR DESCRIPTION
Edited a typo as mae_3 ---> mse_3
Changed model_results array(Comparing Results Section) which had model_3's MAE twice instead of MSE.