### PR TITLE
Update 00_tensorflow_fundamentals.ipynb

### DIFF
--- a/00_tensorflow_fundamentals.ipynb
+++ b/00_tensorflow_fundamentals.ipynb
@@ -326,7 +326,7 @@
       "source": [
         "By default, TensorFlow creates tensors with either an `int32` or `float32` datatype.\n",
         "\n",
-        "This is known as [32-bit precision](https://en.wikipedia.org/wiki/Precision_(computer_science) (the higher the number, the more precise the number, the more space it takes up on your computer)."
+        "This is known as [32-bit precision](https://en.wikipedia.org/wiki/Precision_(computer_science)) (the higher the number, the more precise the number, the more space it takes up on your computer)."
       ]
     },
     {


### PR DESCRIPTION
Fixed hyperlink to Wikipedia article so it works. One closing bracket is for the markdown so it creates the link and the other is for the title for the Wikipedia article itself.

The broken link was to:
https://en.wikipedia.org/wiki/Precision_(computer_science