### PR TITLE
remove icons as part of fixing links

### DIFF
--- a/08_introduction_to_nlp_in_tensorflow.ipynb
+++ b/08_introduction_to_nlp_in_tensorflow.ipynb
@@ -6425,7 +6425,7 @@
         "id": "DJWGI6GpH4Gl"
       },
       "source": [
-        "## 🛠 Exercises\n",
+        "##Exercises\n",
         "\n",
         "1. Rebuild, compile and train `model_1`, `model_2` and `model_5` using the [Keras Sequential API](https://www.tensorflow.org/api_docs/python/tf/keras/Sequential) instead of the Functional API.\n",
         "2. Retrain the baseline model with 10% of the training data. How does perform compared to the Universal Sentence Encoder model with 10% of the training data?\n",
@@ -6450,7 +6450,7 @@
         "id": "BarVJji8H6M4"
       },
       "source": [
-        "## 📖 Extra-curriculum \n",
+        "##Extra-curriculum \n",
         "\n",
         "To practice what you've learned, a good idea would be to spend an hour on 3 of the following (3-hours total, you could through them all if you want) and then write a blog post about what you've learned.\n",
         "\n",


### PR DESCRIPTION
I observed the hyperlinks for the following Exercises and Extra Curriculum is not working due to icons present in the starting of the headline. Hence, removing these icons should fix the issue.

Ref - 
https://dev.mrdbourke.com/tensorflow-deep-learning/08_introduction_to_nlp_in_tensorflow/#exercises
https://dev.mrdbourke.com/tensorflow-deep-learning/08_introduction_to_nlp_in_tensorflow/#extra-curriculum