### PR TITLE
Correct Spell Of 'abitrary'

### DIFF
--- a/video_notebooks/00_tensorflow_fundamentals_video.ipynb
+++ b/video_notebooks/00_tensorflow_fundamentals_video.ipynb
@@ -557,7 +557,7 @@
       "source": [
         "### Creating random tensors\n",
         "\n",
-        "Random tensors are tensors of some abitrary size which contain random numbers."
+        "Random tensors are tensors of some arbitrary size which contain random numbers."
       ]
     },
     {


### PR DESCRIPTION
#Correct Spell Of  `arbitrary`
a word in session  `00_tensorflow_fundamentals_video.ipynb` , should be correct . 
part : Creating random tensors 

`abitrary` ------> `arbitrary`