### PR TITLE
update notebook 00.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "workbench.colorCustomizations": {
+        "activityBar.background": "#2F088C",
+        "titleBar.activeBackground": "#420BC4",
+        "titleBar.activeForeground": "#FAF9FF"
+    }
+}

--- a/00_tensorflow_fundamentals.ipynb
+++ b/00_tensorflow_fundamentals.ipynb
@@ -1,28 +1,10 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "00_tensorflow_fundamentals.ipynb",
-      "provenance": [],
-      "collapsed_sections": [
-        "fzjcZ4FHCOb5"
-      ],
-      "authorship_tag": "ABX9TyMHAtaiFyROOAD0GJ9ufhOp",
-      "include_colab_link": true
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "accelerator": "GPU"
-  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "view-in-github"
       },
       "source": [
         "<a href=\"https://colab.research.google.com/github/mrdbourke/tensorflow-deep-learning/blob/main/00_tensorflow_fundamentals.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
@@ -90,27 +72,30 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "Z7ieIu8t9ijY",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "7548088b-91d5-412f-8544-3f6b3487e33a"
+        "id": "Z7ieIu8t9ijY",
+        "outputId": "7548088b-91d5-412f-8544-3f6b3487e33a",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2.4.1\n"
+          ]
+        }
+      ],
       "source": [
         "# Import TensorFlow\n",
         "import tensorflow as tf\n",
         "print(tf.__version__) # find the version number (should be 2.x+)"
-      ],
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "2.4.1\n"
-          ],
-          "name": "stdout"
-        }
       ]
     },
     {
@@ -130,32 +115,35 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "nC7aQgqi0M_Z",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "89250b3e-86a9-4d9b-b15f-8ae0812dde5b"
+        "id": "nC7aQgqi0M_Z",
+        "outputId": "89250b3e-86a9-4d9b-b15f-8ae0812dde5b",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Create a scalar (rank 0 tensor)\n",
-        "scalar = tf.constant(7)\n",
-        "scalar"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(), dtype=int32, numpy=7>"
             ]
           },
+          "execution_count": 2,
           "metadata": {
             "tags": []
           },
-          "execution_count": 2
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Create a scalar (rank 0 tensor)\n",
+        "scalar = tf.constant(7)\n",
+        "scalar"
       ]
     },
     {
@@ -171,111 +159,116 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "1sgUNKoFkJ21",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "5b244f42-05bc-4702-dc5c-a91716443c4c"
+        "id": "1sgUNKoFkJ21",
+        "outputId": "5b244f42-05bc-4702-dc5c-a91716443c4c",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Check the number of dimensions of a tensor (ndim stands for number of dimensions)\n",
-        "scalar.ndim"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "0"
             ]
           },
+          "execution_count": 3,
           "metadata": {
             "tags": []
           },
-          "execution_count": 3
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Check the number of dimensions of a tensor (ndim stands for number of dimensions)\n",
+        "scalar.ndim"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "irtCo2fs0V_o",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "e424c961-7a1a-4544-ed5a-becc1cc1d1bd"
+        "id": "irtCo2fs0V_o",
+        "outputId": "e424c961-7a1a-4544-ed5a-becc1cc1d1bd",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Create a vector (more than 0 dimensions)\n",
-        "vector = tf.constant([10, 10])\n",
-        "vector"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(2,), dtype=int32, numpy=array([10, 10], dtype=int32)>"
             ]
           },
+          "execution_count": 4,
           "metadata": {
             "tags": []
           },
-          "execution_count": 4
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Create a vector (more than 0 dimensions)\n",
+        "vector = tf.constant([10, 10])\n",
+        "vector"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "7DDc36pvmOse",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "f6fbc397-5058-4f2f-8f27-9d7c6adf4f95"
+        "id": "7DDc36pvmOse",
+        "outputId": "f6fbc397-5058-4f2f-8f27-9d7c6adf4f95",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Check the number of dimensions of our vector tensor\n",
-        "vector.ndim"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "1"
             ]
           },
+          "execution_count": 5,
           "metadata": {
             "tags": []
           },
-          "execution_count": 5
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Check the number of dimensions of our vector tensor\n",
+        "vector.ndim"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "HXf5A5360V7A",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "3f773144-81c5-49d2-819b-192ff0153c03"
+        "id": "HXf5A5360V7A",
+        "outputId": "3f773144-81c5-49d2-819b-192ff0153c03",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Create a matrix (more than 1 dimension)\n",
-        "matrix = tf.constant([[10, 7],\n",
-        "                      [7, 10]])\n",
-        "matrix"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(2, 2), dtype=int32, numpy=\n",
@@ -283,39 +276,49 @@
               "       [ 7, 10]], dtype=int32)>"
             ]
           },
+          "execution_count": 6,
           "metadata": {
             "tags": []
           },
-          "execution_count": 6
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Create a matrix (more than 1 dimension)\n",
+        "matrix = tf.constant([[10, 7],\n",
+        "                      [7, 10]])\n",
+        "matrix"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "Asmn6YghlT6u",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "aa08a360-2917-4be3-e263-b4cea62ed569"
+        "id": "Asmn6YghlT6u",
+        "outputId": "aa08a360-2917-4be3-e263-b4cea62ed569",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "matrix.ndim"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "2"
             ]
           },
+          "execution_count": 7,
           "metadata": {
             "tags": []
           },
-          "execution_count": 7
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "matrix.ndim"
       ]
     },
     {
@@ -331,24 +334,19 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "aEgthLq80V2u",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "f64d9ac7-1a83-4fc3-9511-a02e5e19dd6b"
+        "id": "aEgthLq80V2u",
+        "outputId": "f64d9ac7-1a83-4fc3-9511-a02e5e19dd6b",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Create another matrix and define the datatype\n",
-        "another_matrix = tf.constant([[10., 7.],\n",
-        "                              [3., 2.],\n",
-        "                              [8., 9.]], dtype=tf.float16) # specify the datatype with 'dtype'\n",
-        "another_matrix"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(3, 2), dtype=float16, numpy=\n",
@@ -357,65 +355,68 @@
               "       [ 8.,  9.]], dtype=float16)>"
             ]
           },
+          "execution_count": 8,
           "metadata": {
             "tags": []
           },
-          "execution_count": 8
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Create another matrix and define the datatype\n",
+        "another_matrix = tf.constant([[10., 7.],\n",
+        "                              [3., 2.],\n",
+        "                              [8., 9.]], dtype=tf.float16) # specify the datatype with 'dtype'\n",
+        "another_matrix"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "v-Y-lXdOlXRg",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "7f7c851b-9487-4ce8-de4d-5a747b9912e3"
+        "id": "v-Y-lXdOlXRg",
+        "outputId": "7f7c851b-9487-4ce8-de4d-5a747b9912e3",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Even though another_matrix contains more numbers, its dimensions stay the same\n",
-        "another_matrix.ndim"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "2"
             ]
           },
+          "execution_count": 9,
           "metadata": {
             "tags": []
           },
-          "execution_count": 9
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Even though another_matrix contains more numbers, its dimensions stay the same\n",
+        "another_matrix.ndim"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "fAy7J6fT0Vwz",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "77c91572-9b0a-4e0d-d39f-91455f41ee1e"
+        "id": "fAy7J6fT0Vwz",
+        "outputId": "77c91572-9b0a-4e0d-d39f-91455f41ee1e",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# How about a tensor? (more than 2 dimensions, although, all of the above items are also technically tensors)\n",
-        "tensor = tf.constant([[[1, 2, 3],\n",
-        "                       [4, 5, 6]],\n",
-        "                      [[7, 8, 9],\n",
-        "                       [10, 11, 12]],\n",
-        "                      [[13, 14, 15],\n",
-        "                       [16, 17, 18]]])\n",
-        "tensor"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(3, 2, 3), dtype=int32, numpy=\n",
@@ -429,39 +430,53 @@
               "        [16, 17, 18]]], dtype=int32)>"
             ]
           },
+          "execution_count": 10,
           "metadata": {
             "tags": []
           },
-          "execution_count": 10
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# How about a tensor? (more than 2 dimensions, although, all of the above items are also technically tensors)\n",
+        "tensor = tf.constant([[[1, 2, 3],\n",
+        "                       [4, 5, 6]],\n",
+        "                      [[7, 8, 9],\n",
+        "                       [10, 11, 12]],\n",
+        "                      [[13, 14, 15],\n",
+        "                       [16, 17, 18]]])\n",
+        "tensor"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "FhIsj108mFOS",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "64bf5633-c17f-42b7-ce0a-14e3df8a2dec"
+        "id": "FhIsj108mFOS",
+        "outputId": "64bf5633-c17f-42b7-ce0a-14e3df8a2dec",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "tensor.ndim"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "3"
             ]
           },
+          "execution_count": 11,
           "metadata": {
             "tags": []
           },
-          "execution_count": 11
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "tensor.ndim"
       ]
     },
     {
@@ -507,34 +522,37 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "bv1SBbDe4TxN",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "2af43a4e-9d28-4788-f5f9-ab33c95a6551"
+        "id": "bv1SBbDe4TxN",
+        "outputId": "2af43a4e-9d28-4788-f5f9-ab33c95a6551",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Create the same tensor with tf.Variable() and tf.constant()\n",
-        "changeable_tensor = tf.Variable([10, 7])\n",
-        "unchangeable_tensor = tf.constant([10, 7])\n",
-        "changeable_tensor, unchangeable_tensor"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "(<tf.Variable 'Variable:0' shape=(2,) dtype=int32, numpy=array([10,  7], dtype=int32)>,\n",
               " <tf.Tensor: shape=(2,), dtype=int32, numpy=array([10,  7], dtype=int32)>)"
             ]
           },
+          "execution_count": 12,
           "metadata": {
             "tags": []
           },
-          "execution_count": 12
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Create the same tensor with tf.Variable() and tf.constant()\n",
+        "changeable_tensor = tf.Variable([10, 7])\n",
+        "unchangeable_tensor = tf.constant([10, 7])\n",
+        "changeable_tensor, unchangeable_tensor"
       ]
     },
     {
@@ -548,25 +566,23 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "dfDwbF6i5Sy3",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 200
         },
-        "outputId": "087b7aa3-d371-4741-d798-9aef73895635"
+        "id": "dfDwbF6i5Sy3",
+        "outputId": "087b7aa3-d371-4741-d798-9aef73895635",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Will error (requires the .assign() method)\n",
-        "changeable_tensor[0] = 7\n",
-        "changeable_tensor"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "error",
           "ename": "TypeError",
           "evalue": "ignored",
+          "output_type": "error",
           "traceback": [
             "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
             "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
@@ -574,6 +590,11 @@
             "\u001b[0;31mTypeError\u001b[0m: 'ResourceVariable' object does not support item assignment"
           ]
         }
+      ],
+      "source": [
+        "# Will error (requires the .assign() method)\n",
+        "changeable_tensor[0] = 7\n",
+        "changeable_tensor"
       ]
     },
     {
@@ -587,32 +608,35 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "FJV3iwvG4jg4",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "d110b678-03ff-49e8-dee6-9974ab75ba24"
+        "id": "FJV3iwvG4jg4",
+        "outputId": "d110b678-03ff-49e8-dee6-9974ab75ba24",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Won't error\n",
-        "changeable_tensor[0].assign(7)\n",
-        "changeable_tensor"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Variable 'Variable:0' shape=(2,) dtype=int32, numpy=array([7, 7], dtype=int32)>"
             ]
           },
+          "execution_count": 15,
           "metadata": {
             "tags": []
           },
-          "execution_count": 15
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Won't error\n",
+        "changeable_tensor[0].assign(7)\n",
+        "changeable_tensor"
       ]
     },
     {
@@ -626,25 +650,23 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "5j_rOo8X5N9f",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 200
         },
-        "outputId": "095cb0dc-dda0-41bc-e8dc-995934535957"
+        "id": "5j_rOo8X5N9f",
+        "outputId": "095cb0dc-dda0-41bc-e8dc-995934535957",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Will error (can't change tf.constant())\n",
-        "unchangeable_tensor[0].assign(7)\n",
-        "unchangleable_tensor"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "error",
           "ename": "AttributeError",
           "evalue": "ignored",
+          "output_type": "error",
           "traceback": [
             "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
             "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
@@ -652,6 +674,11 @@
             "\u001b[0;31mAttributeError\u001b[0m: 'tensorflow.python.framework.ops.EagerTensor' object has no attribute 'assign'"
           ]
         }
+      ],
+      "source": [
+        "# Will error (can't change tf.constant())\n",
+        "unchangeable_tensor[0].assign(7)\n",
+        "unchangleable_tensor"
       ]
     },
     {
@@ -690,27 +717,19 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "yZ7Zu5Z178JL",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "79b4497d-0404-4171-f42f-050c854b9019"
+        "id": "yZ7Zu5Z178JL",
+        "outputId": "79b4497d-0404-4171-f42f-050c854b9019",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Create two random (but the same) tensors\n",
-        "random_1 = tf.random.Generator.from_seed(42) # set the seed for reproducibility\n",
-        "random_1 = random_1.normal(shape=(3, 2)) # create tensor from a normal distribution \n",
-        "random_2 = tf.random.Generator.from_seed(42)\n",
-        "random_2 = random_2.normal(shape=(3, 2))\n",
-        "\n",
-        "# Are they equal?\n",
-        "random_1, random_2, random_1 == random_2"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "(<tf.Tensor: shape=(3, 2), dtype=float32, numpy=\n",
@@ -727,11 +746,22 @@
               "        [ True,  True]])>)"
             ]
           },
+          "execution_count": 17,
           "metadata": {
             "tags": []
           },
-          "execution_count": 17
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Create two random (but the same) tensors\n",
+        "random_1 = tf.random.Generator.from_seed(42) # set the seed for reproducibility\n",
+        "random_1 = random_1.normal(shape=(3, 2)) # create tensor from a normal distribution \n",
+        "random_2 = tf.random.Generator.from_seed(42)\n",
+        "random_2 = random_2.normal(shape=(3, 2))\n",
+        "\n",
+        "# Are they equal?\n",
+        "random_1, random_2, random_1 == random_2"
       ]
     },
     {
@@ -751,27 +781,19 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "9eStLqr1F4ZP",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "cf545015-ce96-46dd-9d43-fbb148a04782"
+        "id": "9eStLqr1F4ZP",
+        "outputId": "cf545015-ce96-46dd-9d43-fbb148a04782",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Create two random (and different) tensors\n",
-        "random_3 = tf.random.Generator.from_seed(42)\n",
-        "random_3 = random_3.normal(shape=(3, 2))\n",
-        "random_4 = tf.random.Generator.from_seed(11)\n",
-        "random_4 = random_4.normal(shape=(3, 2))\n",
-        "\n",
-        "# Check the tensors and see if they are equal\n",
-        "random_3, random_4, random_1 == random_3, random_3 == random_4"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "(<tf.Tensor: shape=(3, 2), dtype=float32, numpy=\n",
@@ -792,11 +814,22 @@
               "        [False, False]])>)"
             ]
           },
+          "execution_count": 18,
           "metadata": {
             "tags": []
           },
-          "execution_count": 18
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Create two random (and different) tensors\n",
+        "random_3 = tf.random.Generator.from_seed(42)\n",
+        "random_3 = random_3.normal(shape=(3, 2))\n",
+        "random_4 = tf.random.Generator.from_seed(11)\n",
+        "random_4 = random_4.normal(shape=(3, 2))\n",
+        "\n",
+        "# Check the tensors and see if they are equal\n",
+        "random_3, random_4, random_1 == random_3, random_3 == random_4"
       ]
     },
     {
@@ -814,25 +847,19 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "sl4HYEWMBI6x",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "195d45c3-9c2e-4e7d-ea71-f3382b4dc6b0"
+        "id": "sl4HYEWMBI6x",
+        "outputId": "195d45c3-9c2e-4e7d-ea71-f3382b4dc6b0",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Shuffle a tensor (valuable for when you want to shuffle your data)\n",
-        "not_shuffled = tf.constant([[10, 7],\n",
-        "                            [3, 4],\n",
-        "                            [2, 5]])\n",
-        "# Gets different results each time\n",
-        "tf.random.shuffle(not_shuffled)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(3, 2), dtype=int32, numpy=\n",
@@ -841,30 +868,37 @@
               "       [ 3,  4]], dtype=int32)>"
             ]
           },
+          "execution_count": 19,
           "metadata": {
             "tags": []
           },
-          "execution_count": 19
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Shuffle a tensor (valuable for when you want to shuffle your data)\n",
+        "not_shuffled = tf.constant([[10, 7],\n",
+        "                            [3, 4],\n",
+        "                            [2, 5]])\n",
+        "# Gets different results each time\n",
+        "tf.random.shuffle(not_shuffled)"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "-HYn0ME_H1SY",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "1a5c9383-9ca8-47c2-90a8-d2002dbf4ef8"
+        "id": "-HYn0ME_H1SY",
+        "outputId": "1a5c9383-9ca8-47c2-90a8-d2002dbf4ef8",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Shuffle in the same order every time using the seed parameter (won't acutally be the same)\n",
-        "tf.random.shuffle(not_shuffled, seed=42)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(3, 2), dtype=int32, numpy=\n",
@@ -873,11 +907,16 @@
               "       [10,  7]], dtype=int32)>"
             ]
           },
+          "execution_count": 20,
           "metadata": {
             "tags": []
           },
-          "execution_count": 20
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Shuffle in the same order every time using the seed parameter (won't acutally be the same)\n",
+        "tf.random.shuffle(not_shuffled, seed=42)"
       ]
     },
     {
@@ -899,26 +938,19 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "cM6S8set-ixV",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "3ab2f553-5818-46eb-d276-a14853693bdc"
+        "id": "cM6S8set-ixV",
+        "outputId": "3ab2f553-5818-46eb-d276-a14853693bdc",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Shuffle in the same order every time\n",
-        "\n",
-        "# Set the global random seed\n",
-        "tf.random.set_seed(42)\n",
-        "\n",
-        "# Set the operation random seed\n",
-        "tf.random.shuffle(not_shuffled, seed=42)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(3, 2), dtype=int32, numpy=\n",
@@ -927,33 +959,38 @@
               "       [ 2,  5]], dtype=int32)>"
             ]
           },
+          "execution_count": 21,
           "metadata": {
             "tags": []
           },
-          "execution_count": 21
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Shuffle in the same order every time\n",
+        "\n",
+        "# Set the global random seed\n",
+        "tf.random.set_seed(42)\n",
+        "\n",
+        "# Set the operation random seed\n",
+        "tf.random.shuffle(not_shuffled, seed=42)"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "xKJOsdE8yCn4",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "9cd2788b-95a7-4f31-997c-313a2297541d"
+        "id": "xKJOsdE8yCn4",
+        "outputId": "9cd2788b-95a7-4f31-997c-313a2297541d",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Set the global random seed\n",
-        "tf.random.set_seed(42) # if you comment this out you'll get different results\n",
-        "\n",
-        "# Set the operation random seed\n",
-        "tf.random.shuffle(not_shuffled)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(3, 2), dtype=int32, numpy=\n",
@@ -962,11 +999,19 @@
               "       [10,  7]], dtype=int32)>"
             ]
           },
+          "execution_count": 22,
           "metadata": {
             "tags": []
           },
-          "execution_count": 22
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Set the global random seed\n",
+        "tf.random.set_seed(42) # if you comment this out you'll get different results\n",
+        "\n",
+        "# Set the operation random seed\n",
+        "tf.random.shuffle(not_shuffled)"
       ]
     },
     {
@@ -982,21 +1027,19 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "aG8QNZP7kEe1",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "9ab2ec05-8b1d-45b0-a886-392e63d69149"
+        "id": "aG8QNZP7kEe1",
+        "outputId": "9ab2ec05-8b1d-45b0-a886-392e63d69149",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Make a tensor of all ones\n",
-        "tf.ones(shape=(3, 2))"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(3, 2), dtype=float32, numpy=\n",
@@ -1005,30 +1048,33 @@
               "       [1., 1.]], dtype=float32)>"
             ]
           },
+          "execution_count": 23,
           "metadata": {
             "tags": []
           },
-          "execution_count": 23
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Make a tensor of all ones\n",
+        "tf.ones(shape=(3, 2))"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "GQKiWrB9kprj",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "8cd8ccee-2546-4473-ca89-0789100fbc1c"
+        "id": "GQKiWrB9kprj",
+        "outputId": "8cd8ccee-2546-4473-ca89-0789100fbc1c",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Make a tensor of all zeros\n",
-        "tf.zeros(shape=(3, 2))"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(3, 2), dtype=float32, numpy=\n",
@@ -1037,11 +1083,16 @@
               "       [0., 0.]], dtype=float32)>"
             ]
           },
+          "execution_count": 24,
           "metadata": {
             "tags": []
           },
-          "execution_count": 24
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Make a tensor of all zeros\n",
+        "tf.zeros(shape=(3, 2))"
       ]
     },
     {
@@ -1059,24 +1110,19 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "C0XP37xi7mn4",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "f59af147-58d8-4239-bbc1-1f140a858118"
+        "id": "C0XP37xi7mn4",
+        "outputId": "f59af147-58d8-4239-bbc1-1f140a858118",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "import numpy as np\n",
-        "numpy_A = np.arange(1, 25, dtype=np.int32) # create a NumPy array between 1 and 25\n",
-        "A = tf.constant(numpy_A,  \n",
-        "                shape=[2, 4, 3]) # note: the shape total (2*4*3) has to match the number of elements in the array\n",
-        "numpy_A, A"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "(array([ 1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17,\n",
@@ -1093,11 +1139,19 @@
               "         [22, 23, 24]]], dtype=int32)>)"
             ]
           },
+          "execution_count": 25,
           "metadata": {
             "tags": []
           },
-          "execution_count": 25
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "import numpy as np\n",
+        "numpy_A = np.arange(1, 25, dtype=np.int32) # create a NumPy array between 1 and 25\n",
+        "A = tf.constant(numpy_A,  \n",
+        "                shape=[2, 4, 3]) # note: the shape total (2*4*3) has to match the number of elements in the array\n",
+        "numpy_A, A"
       ]
     },
     {
@@ -1121,22 +1175,19 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "qhckrmovCaAA",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "ac4307f8-d850-4c45-eaff-7cfa8a3919e9"
+        "id": "qhckrmovCaAA",
+        "outputId": "ac4307f8-d850-4c45-eaff-7cfa8a3919e9",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Create a rank 4 tensor (4 dimensions)\n",
-        "rank_4_tensor = tf.zeros([2, 3, 4, 5])\n",
-        "rank_4_tensor"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(2, 3, 4, 5), dtype=float32, numpy=\n",
@@ -1172,62 +1223,66 @@
               "         [0., 0., 0., 0., 0.]]]], dtype=float32)>"
             ]
           },
+          "execution_count": 26,
           "metadata": {
             "tags": []
           },
-          "execution_count": 26
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Create a rank 4 tensor (4 dimensions)\n",
+        "rank_4_tensor = tf.zeros([2, 3, 4, 5])\n",
+        "rank_4_tensor"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "ImJdhWnLtZ_2",
-        "outputId": "92b9e814-51b1-4374-ae81-516dcc2e0c49"
+        "outputId": "92b9e814-51b1-4374-ae81-516dcc2e0c49",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "rank_4_tensor.shape, rank_4_tensor.ndim, tf.size(rank_4_tensor)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "(TensorShape([2, 3, 4, 5]), 4, <tf.Tensor: shape=(), dtype=int32, numpy=120>)"
             ]
           },
+          "execution_count": 27,
           "metadata": {
             "tags": []
           },
-          "execution_count": 27
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "rank_4_tensor.shape, rank_4_tensor.ndim, tf.size(rank_4_tensor)"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "Vvb-4ZYdpI9f",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "0f1b35eb-b93f-422e-8979-17260c621ffb"
+        "id": "Vvb-4ZYdpI9f",
+        "outputId": "0f1b35eb-b93f-422e-8979-17260c621ffb",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Get various attributes of tensor\n",
-        "print(\"Datatype of every element:\", rank_4_tensor.dtype)\n",
-        "print(\"Number of dimensions (rank):\", rank_4_tensor.ndim)\n",
-        "print(\"Shape of tensor:\", rank_4_tensor.shape)\n",
-        "print(\"Elements along axis 0 of tensor:\", rank_4_tensor.shape[0])\n",
-        "print(\"Elements along last axis of tensor:\", rank_4_tensor.shape[-1])\n",
-        "print(\"Total number of elements (2*3*4*5):\", tf.size(rank_4_tensor).numpy()) # .numpy() converts to NumPy array"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "Datatype of every element: <dtype: 'float32'>\n",
@@ -1236,9 +1291,17 @@
             "Elements along axis 0 of tensor: 2\n",
             "Elements along last axis of tensor: 5\n",
             "Total number of elements (2*3*4*5): 120\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "# Get various attributes of tensor\n",
+        "print(\"Datatype of every element:\", rank_4_tensor.dtype)\n",
+        "print(\"Number of dimensions (rank):\", rank_4_tensor.ndim)\n",
+        "print(\"Shape of tensor:\", rank_4_tensor.shape)\n",
+        "print(\"Elements along axis 0 of tensor:\", rank_4_tensor.shape[0])\n",
+        "print(\"Elements along last axis of tensor:\", rank_4_tensor.shape[-1])\n",
+        "print(\"Total number of elements (2*3*4*5):\", tf.size(rank_4_tensor).numpy()) # .numpy() converts to NumPy array"
       ]
     },
     {
@@ -1252,21 +1315,19 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "CFzOo-7QqLJf",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "2629d691-a8de-4488-915a-b06868f5218d"
+        "id": "CFzOo-7QqLJf",
+        "outputId": "2629d691-a8de-4488-915a-b06868f5218d",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Get the first 2 items of each dimension\n",
-        "rank_4_tensor[:2, :2, :2, :2]"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(2, 2, 2, 2), dtype=float32, numpy=\n",
@@ -1284,51 +1345,77 @@
               "         [0., 0.]]]], dtype=float32)>"
             ]
           },
+          "execution_count": 29,
           "metadata": {
             "tags": []
           },
-          "execution_count": 29
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Get the first 2 items of each dimension\n",
+        "rank_4_tensor[:2, :2, :2, :2]"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "weQe2bBUqknd",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "16c61a8c-2ba3-42a3-d4b8-d19185553300"
+        "id": "weQe2bBUqknd",
+        "outputId": "16c61a8c-2ba3-42a3-d4b8-d19185553300",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Get the dimension from each index except for the final one\n",
-        "rank_4_tensor[:1, :1, :1, :]"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(1, 1, 1, 5), dtype=float32, numpy=array([[[[0., 0., 0., 0., 0.]]]], dtype=float32)>"
             ]
           },
+          "execution_count": 30,
           "metadata": {
             "tags": []
           },
-          "execution_count": 30
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Get the dimension from each index except for the final one\n",
+        "rank_4_tensor[:1, :1, :1, :]"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "YQKcZWz5rFXG",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "15a0bee6-6467-46b7-c315-e5ec963de8bd"
+        "id": "YQKcZWz5rFXG",
+        "outputId": "15a0bee6-6467-46b7-c315-e5ec963de8bd",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "<tf.Tensor: shape=(2,), dtype=int32, numpy=array([7, 4], dtype=int32)>"
+            ]
+          },
+          "execution_count": 31,
+          "metadata": {
+            "tags": []
+          },
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "# Create a rank 2 tensor (2 dimensions)\n",
         "rank_2_tensor = tf.constant([[10, 7],\n",
@@ -1336,21 +1423,6 @@
         "\n",
         "# Get the last item of each row\n",
         "rank_2_tensor[:, -1]"
-      ],
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "<tf.Tensor: shape=(2,), dtype=int32, numpy=array([7, 4], dtype=int32)>"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 31
-        }
       ]
     },
     {
@@ -1364,22 +1436,19 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "KuEEEQa4w1id",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "998dcc25-889f-4c5b-e417-f9e45dcaa350"
+        "id": "KuEEEQa4w1id",
+        "outputId": "998dcc25-889f-4c5b-e417-f9e45dcaa350",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Add an extra dimension (to the end)\n",
-        "rank_3_tensor = rank_2_tensor[..., tf.newaxis] # in Python \"...\" means \"all dimensions prior to\"\n",
-        "rank_2_tensor, rank_3_tensor # shape (2, 2), shape (2, 2, 1)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "(<tf.Tensor: shape=(2, 2), dtype=int32, numpy=\n",
@@ -1393,11 +1462,17 @@
               "         [ 4]]], dtype=int32)>)"
             ]
           },
+          "execution_count": 32,
           "metadata": {
             "tags": []
           },
-          "execution_count": 32
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Add an extra dimension (to the end)\n",
+        "rank_3_tensor = rank_2_tensor[..., tf.newaxis] # in Python \"...\" means \"all dimensions prior to\"\n",
+        "rank_2_tensor, rank_3_tensor # shape (2, 2), shape (2, 2, 1)"
       ]
     },
     {
@@ -1411,20 +1486,19 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "HpPTBqt4rvr9",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "47a95be1-ba16-475f-b2cd-437f115cd5ac"
+        "id": "HpPTBqt4rvr9",
+        "outputId": "47a95be1-ba16-475f-b2cd-437f115cd5ac",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "tf.expand_dims(rank_2_tensor, axis=-1) # \"-1\" means last axis"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(2, 2, 1), dtype=int32, numpy=\n",
@@ -1435,11 +1509,15 @@
               "        [ 4]]], dtype=int32)>"
             ]
           },
+          "execution_count": 33,
           "metadata": {
             "tags": []
           },
-          "execution_count": 33
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "tf.expand_dims(rank_2_tensor, axis=-1) # \"-1\" means last axis"
       ]
     },
     {
@@ -1468,22 +1546,19 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "tu3zJirLsMVw",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "7dce405b-292e-4d7a-efdd-eeda89807887"
+        "id": "tu3zJirLsMVw",
+        "outputId": "7dce405b-292e-4d7a-efdd-eeda89807887",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# You can add values to a tensor using the addition operator\n",
-        "tensor = tf.constant([[10, 7], [3, 4]])\n",
-        "tensor + 10"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(2, 2), dtype=int32, numpy=\n",
@@ -1491,11 +1566,17 @@
               "       [13, 14]], dtype=int32)>"
             ]
           },
+          "execution_count": 34,
           "metadata": {
             "tags": []
           },
-          "execution_count": 34
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# You can add values to a tensor using the addition operator\n",
+        "tensor = tf.constant([[10, 7], [3, 4]])\n",
+        "tensor + 10"
       ]
     },
     {
@@ -1509,21 +1590,19 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "BhJn3puhwOlM",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "92ce1cbe-e4c8-4f4e-c50b-c21d4ea57d43"
+        "id": "BhJn3puhwOlM",
+        "outputId": "92ce1cbe-e4c8-4f4e-c50b-c21d4ea57d43",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Original tensor unchanged\n",
-        "tensor"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(2, 2), dtype=int32, numpy=\n",
@@ -1531,11 +1610,16 @@
               "       [ 3,  4]], dtype=int32)>"
             ]
           },
+          "execution_count": 35,
           "metadata": {
             "tags": []
           },
-          "execution_count": 35
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Original tensor unchanged\n",
+        "tensor"
       ]
     },
     {
@@ -1549,21 +1633,19 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "6TW0_ZC_xoEC",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "f6aa4f99-a9e8-4e13-c06c-5c9450ef99c4"
+        "id": "6TW0_ZC_xoEC",
+        "outputId": "f6aa4f99-a9e8-4e13-c06c-5c9450ef99c4",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Multiplication (known as element-wise multiplication)\n",
-        "tensor * 10"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(2, 2), dtype=int32, numpy=\n",
@@ -1571,30 +1653,33 @@
               "       [ 30,  40]], dtype=int32)>"
             ]
           },
+          "execution_count": 36,
           "metadata": {
             "tags": []
           },
-          "execution_count": 36
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Multiplication (known as element-wise multiplication)\n",
+        "tensor * 10"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "MN6XjwWfxu66",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "ca0a775c-e2e3-4a53-fbae-e4ced3f2c91c"
+        "id": "MN6XjwWfxu66",
+        "outputId": "ca0a775c-e2e3-4a53-fbae-e4ced3f2c91c",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Subtraction\n",
-        "tensor - 10"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(2, 2), dtype=int32, numpy=\n",
@@ -1602,11 +1687,16 @@
               "       [-7, -6]], dtype=int32)>"
             ]
           },
+          "execution_count": 37,
           "metadata": {
             "tags": []
           },
-          "execution_count": 37
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Subtraction\n",
+        "tensor - 10"
       ]
     },
     {
@@ -1620,21 +1710,19 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "R2NDjqYIyyMc",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "b811b7c6-2c4a-4f89-fae6-89ceaf8dfa5e"
+        "id": "R2NDjqYIyyMc",
+        "outputId": "b811b7c6-2c4a-4f89-fae6-89ceaf8dfa5e",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Use the tensorflow function equivalent of the '*' (multiply) operator\n",
-        "tf.multiply(tensor, 10)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(2, 2), dtype=int32, numpy=\n",
@@ -1642,30 +1730,33 @@
               "       [ 30,  40]], dtype=int32)>"
             ]
           },
+          "execution_count": 38,
           "metadata": {
             "tags": []
           },
-          "execution_count": 38
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Use the tensorflow function equivalent of the '*' (multiply) operator\n",
+        "tf.multiply(tensor, 10)"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "lKEuDBFD49w7",
-        "outputId": "99300b75-0f81-432b-f3d0-b32e4c651b5b"
+        "outputId": "99300b75-0f81-432b-f3d0-b32e4c651b5b",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# The original tensor is still unchanged\n",
-        "tensor"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(2, 2), dtype=int32, numpy=\n",
@@ -1673,11 +1764,16 @@
               "       [ 3,  4]], dtype=int32)>"
             ]
           },
+          "execution_count": 39,
           "metadata": {
             "tags": []
           },
-          "execution_count": 39
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# The original tensor is still unchanged\n",
+        "tensor"
       ]
     },
     {
@@ -1706,31 +1802,28 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "pbpwVJrAsPpA",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "580b001a-f0c1-45ef-9918-cc5538b0fb1e"
+        "id": "pbpwVJrAsPpA",
+        "outputId": "580b001a-f0c1-45ef-9918-cc5538b0fb1e",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Matrix multiplication in TensorFlow\n",
-        "print(tensor)\n",
-        "tf.matmul(tensor, tensor)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "tf.Tensor(\n",
             "[[10  7]\n",
             " [ 3  4]], shape=(2, 2), dtype=int32)\n"
-          ],
-          "name": "stdout"
+          ]
         },
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(2, 2), dtype=int32, numpy=\n",
@@ -1738,30 +1831,34 @@
               "       [ 42,  37]], dtype=int32)>"
             ]
           },
+          "execution_count": 40,
           "metadata": {
             "tags": []
           },
-          "execution_count": 40
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Matrix multiplication in TensorFlow\n",
+        "print(tensor)\n",
+        "tf.matmul(tensor, tensor)"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "9vpDnpb10G7U",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "6693b6f2-e529-41f3-b08b-c19a90df1137"
+        "id": "9vpDnpb10G7U",
+        "outputId": "6693b6f2-e529-41f3-b08b-c19a90df1137",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Matrix multiplication with Python operator '@'\n",
-        "tensor @ tensor"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(2, 2), dtype=int32, numpy=\n",
@@ -1769,11 +1866,16 @@
               "       [ 42,  37]], dtype=int32)>"
             ]
           },
+          "execution_count": 41,
           "metadata": {
             "tags": []
           },
-          "execution_count": 41
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Matrix multiplication with Python operator '@'\n",
+        "tensor @ tensor"
       ]
     },
     {
@@ -1789,29 +1891,19 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "UXSE6q1o0amm",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "77694ca8-b6c5-4997-8e0e-9cb43bd78145"
+        "id": "UXSE6q1o0amm",
+        "outputId": "77694ca8-b6c5-4997-8e0e-9cb43bd78145",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Create (3, 2) tensor\n",
-        "X = tf.constant([[1, 2],\n",
-        "                 [3, 4],\n",
-        "                 [5, 6]])\n",
-        "\n",
-        "# Create another (3, 2) tensor\n",
-        "Y = tf.constant([[7, 8],\n",
-        "                 [9, 10],\n",
-        "                 [11, 12]])\n",
-        "X, Y"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "(<tf.Tensor: shape=(3, 2), dtype=int32, numpy=\n",
@@ -1823,33 +1915,45 @@
               "        [11, 12]], dtype=int32)>)"
             ]
           },
+          "execution_count": 42,
           "metadata": {
             "tags": []
           },
-          "execution_count": 42
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Create (3, 2) tensor\n",
+        "X = tf.constant([[1, 2],\n",
+        "                 [3, 4],\n",
+        "                 [5, 6]])\n",
+        "\n",
+        "# Create another (3, 2) tensor\n",
+        "Y = tf.constant([[7, 8],\n",
+        "                 [9, 10],\n",
+        "                 [11, 12]])\n",
+        "X, Y"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "3J4DGQa309Hc",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 241
         },
-        "outputId": "d7a867bd-6c5f-4ef9-b9a9-b00c89b1cba1"
+        "id": "3J4DGQa309Hc",
+        "outputId": "d7a867bd-6c5f-4ef9-b9a9-b00c89b1cba1",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Try to matrix multiply them (will error)\n",
-        "X @ Y"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "error",
           "ename": "InvalidArgumentError",
           "evalue": "ignored",
+          "output_type": "error",
           "traceback": [
             "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
             "\u001b[0;31mInvalidArgumentError\u001b[0m                      Traceback (most recent call last)",
@@ -1863,6 +1967,10 @@
             "\u001b[0;31mInvalidArgumentError\u001b[0m: Matrix size-incompatible: In[0]: [3,2], In[1]: [3,2] [Op:MatMul]"
           ]
         }
+      ],
+      "source": [
+        "# Try to matrix multiply them (will error)\n",
+        "X @ Y"
       ]
     },
     {
@@ -1888,21 +1996,19 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "ZwvVl-k_2W9u",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "e408fd19-4705-476d-f1c5-302ff6859e54"
+        "id": "ZwvVl-k_2W9u",
+        "outputId": "e408fd19-4705-476d-f1c5-302ff6859e54",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Example of reshape (3, 2) -> (2, 3)\n",
-        "tf.reshape(Y, shape=(2, 3))"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(2, 3), dtype=int32, numpy=\n",
@@ -1910,30 +2016,33 @@
               "       [10, 11, 12]], dtype=int32)>"
             ]
           },
+          "execution_count": 44,
           "metadata": {
             "tags": []
           },
-          "execution_count": 44
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Example of reshape (3, 2) -> (2, 3)\n",
+        "tf.reshape(Y, shape=(2, 3))"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "1jBKPQVn1Nep",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "19906c7b-3e3b-4611-a639-7c8a3fff1d6a"
+        "id": "1jBKPQVn1Nep",
+        "outputId": "19906c7b-3e3b-4611-a639-7c8a3fff1d6a",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Try matrix multiplication with reshaped Y\n",
-        "X @ tf.reshape(Y, shape=(2, 3))"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(3, 3), dtype=int32, numpy=\n",
@@ -1942,11 +2051,16 @@
               "       [ 95, 106, 117]], dtype=int32)>"
             ]
           },
+          "execution_count": 45,
           "metadata": {
             "tags": []
           },
-          "execution_count": 45
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Try matrix multiplication with reshaped Y\n",
+        "X @ tf.reshape(Y, shape=(2, 3))"
       ]
     },
     {
@@ -1960,21 +2074,19 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "qA2rCnik2OnQ",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "f23907d3-f052-4702-dcbb-371e0ccb8df3"
+        "id": "qA2rCnik2OnQ",
+        "outputId": "f23907d3-f052-4702-dcbb-371e0ccb8df3",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Example of transpose (3, 2) -> (2, 3)\n",
-        "tf.transpose(X)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(2, 3), dtype=int32, numpy=\n",
@@ -1982,61 +2094,67 @@
               "       [2, 4, 6]], dtype=int32)>"
             ]
           },
+          "execution_count": 46,
           "metadata": {
             "tags": []
           },
-          "execution_count": 46
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Example of transpose (3, 2) -> (2, 3)\n",
+        "tf.transpose(X)"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "zR8YdMfh3G0S",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "cd2fbe33-97c6-4e54-c27f-8febe63c8e4f"
+        "id": "zR8YdMfh3G0S",
+        "outputId": "cd2fbe33-97c6-4e54-c27f-8febe63c8e4f",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "<tf.Tensor: shape=(2, 2), dtype=int32, numpy=\n",
+              "array([[ 89,  98],\n",
+              "       [116, 128]], dtype=int32)>"
+            ]
+          },
+          "execution_count": 47,
+          "metadata": {
+            "tags": []
+          },
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "# Try matrix multiplication \n",
         "tf.matmul(tf.transpose(X), Y)"
-      ],
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "<tf.Tensor: shape=(2, 2), dtype=int32, numpy=\n",
-              "array([[ 89,  98],\n",
-              "       [116, 128]], dtype=int32)>"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 47
-        }
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "SL45P1cC5tnJ",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "b2aa00a3-c1e2-44a5-a574-48a0a721f0ee"
+        "id": "SL45P1cC5tnJ",
+        "outputId": "b2aa00a3-c1e2-44a5-a574-48a0a721f0ee",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# You can achieve the same result with parameters\n",
-        "tf.matmul(a=X, b=Y, transpose_a=True, transpose_b=False)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(2, 2), dtype=int32, numpy=\n",
@@ -2044,11 +2162,16 @@
               "       [116, 128]], dtype=int32)>"
             ]
           },
+          "execution_count": 48,
           "metadata": {
             "tags": []
           },
-          "execution_count": 48
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# You can achieve the same result with parameters\n",
+        "tf.matmul(a=X, b=Y, transpose_a=True, transpose_b=False)"
       ]
     },
     {
@@ -2074,21 +2197,19 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "qfSJHDpe2Oe9",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "67aab203-89c1-4b2f-afe5-b96416f043d9"
+        "id": "qfSJHDpe2Oe9",
+        "outputId": "67aab203-89c1-4b2f-afe5-b96416f043d9",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Perform the dot product on X and Y (requires X to be transposed)\n",
-        "tf.tensordot(tf.transpose(X), Y, axes=1)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(2, 2), dtype=int32, numpy=\n",
@@ -2096,11 +2217,16 @@
               "       [116, 128]], dtype=int32)>"
             ]
           },
+          "execution_count": 49,
           "metadata": {
             "tags": []
           },
-          "execution_count": 49
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Perform the dot product on X and Y (requires X to be transposed)\n",
+        "tf.tensordot(tf.transpose(X), Y, axes=1)"
       ]
     },
     {
@@ -2116,21 +2242,19 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "AAzB-F4l6Dc0",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "f2c1545c-e2e5-4e03-9319-65985cd299da"
+        "id": "AAzB-F4l6Dc0",
+        "outputId": "f2c1545c-e2e5-4e03-9319-65985cd299da",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Perform matrix multiplication between X and Y (transposed)\n",
-        "tf.matmul(X, tf.transpose(Y))"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(3, 3), dtype=int32, numpy=\n",
@@ -2139,30 +2263,33 @@
               "       [ 83, 105, 127]], dtype=int32)>"
             ]
           },
+          "execution_count": 50,
           "metadata": {
             "tags": []
           },
-          "execution_count": 50
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Perform matrix multiplication between X and Y (transposed)\n",
+        "tf.matmul(X, tf.transpose(Y))"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "s-kQH7qh69PV",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "f8ff25a7-a7e6-4fbc-c1b7-91059ca8cfa7"
+        "id": "s-kQH7qh69PV",
+        "outputId": "f8ff25a7-a7e6-4fbc-c1b7-91059ca8cfa7",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Perform matrix multiplication between X and Y (reshaped)\n",
-        "tf.matmul(X, tf.reshape(Y, (2, 3)))"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(3, 3), dtype=int32, numpy=\n",
@@ -2171,11 +2298,16 @@
               "       [ 95, 106, 117]], dtype=int32)>"
             ]
           },
+          "execution_count": 51,
           "metadata": {
             "tags": []
           },
-          "execution_count": 51
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Perform matrix multiplication between X and Y (reshaped)\n",
+        "tf.matmul(X, tf.reshape(Y, (2, 3)))"
       ]
     },
     {
@@ -2191,31 +2323,34 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "P_RLV373ATAb",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "202e1c47-504a-4254-bcab-faac96ab9f86"
+        "id": "P_RLV373ATAb",
+        "outputId": "202e1c47-504a-4254-bcab-faac96ab9f86",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Check shapes of Y, reshaped Y and tranposed Y\n",
-        "Y.shape, tf.reshape(Y, (2, 3)).shape, tf.transpose(Y).shape"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "(TensorShape([3, 2]), TensorShape([2, 3]), TensorShape([2, 3]))"
             ]
           },
+          "execution_count": 52,
           "metadata": {
             "tags": []
           },
-          "execution_count": 52
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Check shapes of Y, reshaped Y and tranposed Y\n",
+        "Y.shape, tf.reshape(Y, (2, 3)).shape, tf.transpose(Y).shape"
       ]
     },
     {
@@ -2229,27 +2364,20 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "B5_aYjqeA_w_",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "39d8c934-c06e-4442-8a9d-fb91a7fb82e2"
+        "id": "B5_aYjqeA_w_",
+        "outputId": "39d8c934-c06e-4442-8a9d-fb91a7fb82e2",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Check values of Y, reshape Y and tranposed Y\n",
-        "print(\"Normal Y:\")\n",
-        "print(Y, \"\\n\") # \"\\n\" for newline\n",
-        "\n",
-        "print(\"Y reshaped to (2, 3):\")\n",
-        "print(tf.reshape(Y, (2, 3)), \"\\n\")\n",
-        "\n",
-        "print(\"Y transposed:\")\n",
-        "print(tf.transpose(Y))"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "Normal Y:\n",
@@ -2267,9 +2395,19 @@
             "tf.Tensor(\n",
             "[[ 7  9 11]\n",
             " [ 8 10 12]], shape=(2, 3), dtype=int32)\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "# Check values of Y, reshape Y and tranposed Y\n",
+        "print(\"Normal Y:\")\n",
+        "print(Y, \"\\n\") # \"\\n\" for newline\n",
+        "\n",
+        "print(\"Y reshaped to (2, 3):\")\n",
+        "print(tf.reshape(Y, (2, 3)), \"\\n\")\n",
+        "\n",
+        "print(\"Y transposed:\")\n",
+        "print(tf.transpose(Y))"
       ]
     },
     {
@@ -2324,13 +2462,32 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "jRkZhW35Lge_",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "a205ee88-9f2f-485c-e6e5-3be0b080fb6f"
+        "id": "jRkZhW35Lge_",
+        "outputId": "a205ee88-9f2f-485c-e6e5-3be0b080fb6f",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "(<tf.Tensor: shape=(2,), dtype=float32, numpy=array([1.7, 7.4], dtype=float32)>,\n",
+              " <tf.Tensor: shape=(2,), dtype=int32, numpy=array([1, 7], dtype=int32)>)"
+            ]
+          },
+          "execution_count": 54,
+          "metadata": {
+            "tags": []
+          },
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "# Create a new tensor with default datatype (float32)\n",
         "B = tf.constant([1.7, 7.4])\n",
@@ -2338,82 +2495,72 @@
         "# Create a new tensor with default datatype (int32)\n",
         "C = tf.constant([1, 7])\n",
         "B, C"
-      ],
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "(<tf.Tensor: shape=(2,), dtype=float32, numpy=array([1.7, 7.4], dtype=float32)>,\n",
-              " <tf.Tensor: shape=(2,), dtype=int32, numpy=array([1, 7], dtype=int32)>)"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 54
-        }
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "kdhV1rgcNpUP",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "83a85f1c-fdd3-44e9-f854-75c36b94af3b"
+        "id": "kdhV1rgcNpUP",
+        "outputId": "83a85f1c-fdd3-44e9-f854-75c36b94af3b",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Change from float32 to float16 (reduced precision)\n",
-        "B = tf.cast(B, dtype=tf.float16)\n",
-        "B"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(2,), dtype=float16, numpy=array([1.7, 7.4], dtype=float16)>"
             ]
           },
+          "execution_count": 55,
           "metadata": {
             "tags": []
           },
-          "execution_count": 55
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Change from float32 to float16 (reduced precision)\n",
+        "B = tf.cast(B, dtype=tf.float16)\n",
+        "B"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "Px2E1ANeNxRv",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "be744bf6-beca-4b27-e63d-ae1255be0593"
+        "id": "Px2E1ANeNxRv",
+        "outputId": "be744bf6-beca-4b27-e63d-ae1255be0593",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Change from int32 to float32\n",
-        "C = tf.cast(C, dtype=tf.float32)\n",
-        "C"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(2,), dtype=float32, numpy=array([1., 7.], dtype=float32)>"
             ]
           },
+          "execution_count": 56,
           "metadata": {
             "tags": []
           },
-          "execution_count": 56
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Change from int32 to float32\n",
+        "C = tf.cast(C, dtype=tf.float32)\n",
+        "C"
       ]
     },
     {
@@ -2430,61 +2577,67 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "plNBFi51QOvW",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "79dbe7c8-e212-4b0d-9ee1-965c496afe28"
+        "id": "plNBFi51QOvW",
+        "outputId": "79dbe7c8-e212-4b0d-9ee1-965c496afe28",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Create tensor with negative values\n",
-        "D = tf.constant([-7, -10])\n",
-        "D"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(2,), dtype=int32, numpy=array([ -7, -10], dtype=int32)>"
             ]
           },
+          "execution_count": 57,
           "metadata": {
             "tags": []
           },
-          "execution_count": 57
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Create tensor with negative values\n",
+        "D = tf.constant([-7, -10])\n",
+        "D"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "bOSYmX37QFHS",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "8aa0a217-54e1-4edf-b812-4b0eb05f61a5"
+        "id": "bOSYmX37QFHS",
+        "outputId": "8aa0a217-54e1-4edf-b812-4b0eb05f61a5",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Get the absolute values\n",
-        "tf.abs(D)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(2,), dtype=int32, numpy=array([ 7, 10], dtype=int32)>"
             ]
           },
+          "execution_count": 58,
           "metadata": {
             "tags": []
           },
-          "execution_count": 58
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Get the absolute values\n",
+        "tf.abs(D)"
       ]
     },
     {
@@ -2509,22 +2662,19 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "kjW5_6i6Q7oo",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "7145a7b4-d9da-4120-a2cb-5ebe2bbc0f17"
+        "id": "kjW5_6i6Q7oo",
+        "outputId": "7145a7b4-d9da-4120-a2cb-5ebe2bbc0f17",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Create a tensor with 50 random values between 0 and 100\n",
-        "E = tf.constant(np.random.randint(low=0, high=100, size=50))\n",
-        "E"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(50,), dtype=int64, numpy=\n",
@@ -2533,136 +2683,155 @@
               "       39, 37,  3, 63, 13, 37, 72, 80, 93, 29, 61, 82, 85, 40, 79, 14])>"
             ]
           },
+          "execution_count": 59,
           "metadata": {
             "tags": []
           },
-          "execution_count": 59
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Create a tensor with 50 random values between 0 and 100\n",
+        "E = tf.constant(np.random.randint(low=0, high=100, size=50))\n",
+        "E"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "slwMVgT-Rac0",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "34cf2c05-53b9-44eb-9df5-28df227794d4"
+        "id": "slwMVgT-Rac0",
+        "outputId": "34cf2c05-53b9-44eb-9df5-28df227794d4",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Find the minimum\n",
-        "tf.reduce_min(E)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(), dtype=int64, numpy=2>"
             ]
           },
+          "execution_count": 60,
           "metadata": {
             "tags": []
           },
-          "execution_count": 60
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Find the minimum\n",
+        "tf.reduce_min(E)"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "voLqafGCRYqO",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "8bec8619-45e8-4b95-970b-4ee3b7c55d77"
+        "id": "voLqafGCRYqO",
+        "outputId": "8bec8619-45e8-4b95-970b-4ee3b7c55d77",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Find the maximum\n",
-        "tf.reduce_max(E)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(), dtype=int64, numpy=93>"
             ]
           },
+          "execution_count": 61,
           "metadata": {
             "tags": []
           },
-          "execution_count": 61
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Find the maximum\n",
+        "tf.reduce_max(E)"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "MPqwvy6TRYN3",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "905c4bf8-5d3f-443f-f92b-74752800987a"
+        "id": "MPqwvy6TRYN3",
+        "outputId": "905c4bf8-5d3f-443f-f92b-74752800987a",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Find the mean\n",
-        "tf.reduce_mean(E)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(), dtype=int64, numpy=45>"
             ]
           },
+          "execution_count": 62,
           "metadata": {
             "tags": []
           },
-          "execution_count": 62
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Find the mean\n",
+        "tf.reduce_mean(E)"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "lqwCXeD6RhyE",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "4ce00693-124a-4875-a942-5a48672ace3c"
+        "id": "lqwCXeD6RhyE",
+        "outputId": "4ce00693-124a-4875-a942-5a48672ace3c",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Find the sum\n",
-        "tf.reduce_sum(E)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(), dtype=int64, numpy=2262>"
             ]
           },
+          "execution_count": 63,
           "metadata": {
             "tags": []
           },
-          "execution_count": 63
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Find the sum\n",
+        "tf.reduce_sum(E)"
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "zXGyiVPiRqgO"
       },
       "source": [
-        "You can also find the standard deviation ([`tf.reduce_std()`](https://www.tensorflow.org/api_docs/python/tf/math/reduce_std)) and variance ([`tf.reduce_variance()`](https://www.tensorflow.org/api_docs/python/tf/math/reduce_variance)) of elements in a tensor using similar methods.\n",
+        "You can also find the standard deviation ([`tf.math.reduce_std()`](https://www.tensorflow.org/api_docs/python/tf/math/reduce_std)) and variance ([`tf.math.reduce_variance()`](https://www.tensorflow.org/api_docs/python/tf/math/reduce_variance)) of elements in a tensor using similar methods.\n",
         "\n",
         "### Finding the positional maximum and minimum\n",
         "\n",
@@ -2679,22 +2848,19 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "PspO0Vjp3Nm6",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "74c67bd9-a883-4b67-a7a3-55654d506e77"
+        "id": "PspO0Vjp3Nm6",
+        "outputId": "74c67bd9-a883-4b67-a7a3-55654d506e77",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Create a tensor with 50 values between 0 and 1\n",
-        "F = tf.constant(np.random.random(50))\n",
-        "F"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(50,), dtype=float64, numpy=\n",
@@ -2710,99 +2876,114 @@
               "       0.05419892, 0.10267899, 0.6020753 , 0.78038818, 0.87655176])>"
             ]
           },
+          "execution_count": 64,
           "metadata": {
             "tags": []
           },
-          "execution_count": 64
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Create a tensor with 50 values between 0 and 1\n",
+        "F = tf.constant(np.random.random(50))\n",
+        "F"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "ADbAMm9N3Zlb",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "6fc95755-3b77-495e-f382-0a8b7f2cdef2"
+        "id": "ADbAMm9N3Zlb",
+        "outputId": "6fc95755-3b77-495e-f382-0a8b7f2cdef2",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Find the maximum element position of F\n",
-        "tf.argmax(F)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(), dtype=int64, numpy=8>"
             ]
           },
+          "execution_count": 65,
           "metadata": {
             "tags": []
           },
-          "execution_count": 65
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Find the maximum element position of F\n",
+        "tf.argmax(F)"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "aQrv1nVE3ckx",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "0a78d68f-6804-4125-da7c-d12a6811258e"
+        "id": "aQrv1nVE3ckx",
+        "outputId": "0a78d68f-6804-4125-da7c-d12a6811258e",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Find the minimum element position of F\n",
-        "tf.argmin(F)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(), dtype=int64, numpy=31>"
             ]
           },
+          "execution_count": 66,
           "metadata": {
             "tags": []
           },
-          "execution_count": 66
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Find the minimum element position of F\n",
+        "tf.argmin(F)"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "yFHzARFwLmIf",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "2fbf3ccb-5ae2-4f20-c351-ed98401a135d"
+        "id": "yFHzARFwLmIf",
+        "outputId": "2fbf3ccb-5ae2-4f20-c351-ed98401a135d",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Find the maximum element position of F\n",
-        "print(f\"The maximum value of F is at position: {tf.argmax(F).numpy()}\") \n",
-        "print(f\"The maximum value of F is: {tf.reduce_max(F).numpy()}\") \n",
-        "print(f\"Using tf.argmax() to index F, the maximum value of F is: {F[tf.argmax(F)].numpy()}\")\n",
-        "print(f\"Are the two max values the same (they should be)? {F[tf.argmax(F)].numpy() == tf.reduce_max(F).numpy()}\")"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "The maximum value of F is at position: 8\n",
             "The maximum value of F is: 0.9749826885110175\n",
             "Using tf.argmax() to index F, the maximum value of F is: 0.9749826885110175\n",
             "Are the two max values the same (they should be)? True\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "# Find the maximum element position of F\n",
+        "print(f\"The maximum value of F is at position: {tf.argmax(F).numpy()}\") \n",
+        "print(f\"The maximum value of F is: {tf.reduce_max(F).numpy()}\") \n",
+        "print(f\"Using tf.argmax() to index F, the maximum value of F is: {F[tf.argmax(F)].numpy()}\")\n",
+        "print(f\"Are the two max values the same (they should be)? {F[tf.argmax(F)].numpy() == tf.reduce_max(F).numpy()}\")"
       ]
     },
     {
@@ -2820,62 +3001,68 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "6xDZLtNu5wUZ",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "b86ca328-b539-4701-e729-b7dc5c80dc49"
+        "id": "6xDZLtNu5wUZ",
+        "outputId": "b86ca328-b539-4701-e729-b7dc5c80dc49",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Create a rank 5 (5 dimensions) tensor of 50 numbers between 0 and 100\n",
-        "G = tf.constant(np.random.randint(0, 100, 50), shape=(1, 1, 1, 1, 50))\n",
-        "G.shape, G.ndim"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "(TensorShape([1, 1, 1, 1, 50]), 5)"
             ]
           },
+          "execution_count": 68,
           "metadata": {
             "tags": []
           },
-          "execution_count": 68
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Create a rank 5 (5 dimensions) tensor of 50 numbers between 0 and 100\n",
+        "G = tf.constant(np.random.randint(0, 100, 50), shape=(1, 1, 1, 1, 50))\n",
+        "G.shape, G.ndim"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "oS91XOgO6lai",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "0359d710-ca66-40c1-ac48-cd60c164f5fe"
+        "id": "oS91XOgO6lai",
+        "outputId": "0359d710-ca66-40c1-ac48-cd60c164f5fe",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Squeeze tensor G (remove all 1 dimensions)\n",
-        "G_squeezed = tf.squeeze(G)\n",
-        "G_squeezed.shape, G_squeezed.ndim"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "(TensorShape([50]), 1)"
             ]
           },
+          "execution_count": 69,
           "metadata": {
             "tags": []
           },
-          "execution_count": 69
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Squeeze tensor G (remove all 1 dimensions)\n",
+        "G_squeezed = tf.squeeze(G)\n",
+        "G_squeezed.shape, G_squeezed.ndim"
       ]
     },
     {
@@ -2893,24 +3080,19 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "FlRkMjL-646U",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "f49a6bee-e62a-4175-b84c-e4f8b5500d4f"
+        "id": "FlRkMjL-646U",
+        "outputId": "f49a6bee-e62a-4175-b84c-e4f8b5500d4f",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Create a list of indices\n",
-        "some_list = [0, 1, 2, 3]\n",
-        "\n",
-        "# One hot encode them\n",
-        "tf.one_hot(some_list, depth=4)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(4, 4), dtype=float32, numpy=\n",
@@ -2920,11 +3102,19 @@
               "       [0., 0., 0., 1.]], dtype=float32)>"
             ]
           },
+          "execution_count": 70,
           "metadata": {
             "tags": []
           },
-          "execution_count": 70
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Create a list of indices\n",
+        "some_list = [0, 1, 2, 3]\n",
+        "\n",
+        "# One hot encode them\n",
+        "tf.one_hot(some_list, depth=4)"
       ]
     },
     {
@@ -2938,21 +3128,19 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "FZluadm88EcN",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "a129f06b-b23f-40d8-ed3a-ddbee35be070"
+        "id": "FZluadm88EcN",
+        "outputId": "a129f06b-b23f-40d8-ed3a-ddbee35be070",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Specify custom values for on and off encoding\n",
-        "tf.one_hot(some_list, depth=4, on_value=\"We're live!\", off_value=\"Offline\")"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(4, 4), dtype=string, numpy=\n",
@@ -2962,11 +3150,16 @@
               "       [b'Offline', b'Offline', b'Offline', b\"We're live!\"]], dtype=object)>"
             ]
           },
+          "execution_count": 71,
           "metadata": {
             "tags": []
           },
-          "execution_count": 71
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Specify custom values for on and off encoding\n",
+        "tf.one_hot(some_list, depth=4, on_value=\"We're live!\", off_value=\"Offline\")"
       ]
     },
     {
@@ -2987,83 +3180,88 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "KTOvziCBLqhZ",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "9ef46ed1-6bd2-4e61-9068-11f5bb183150"
+        "id": "KTOvziCBLqhZ",
+        "outputId": "9ef46ed1-6bd2-4e61-9068-11f5bb183150",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Create a new tensor\n",
-        "H = tf.constant(np.arange(1, 10))\n",
-        "H"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(9,), dtype=int64, numpy=array([1, 2, 3, 4, 5, 6, 7, 8, 9])>"
             ]
           },
+          "execution_count": 72,
           "metadata": {
             "tags": []
           },
-          "execution_count": 72
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Create a new tensor\n",
+        "H = tf.constant(np.arange(1, 10))\n",
+        "H"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "qvPS3xbk9JBK",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "999851d2-5a61-4768-8a43-1b1862ffb0bd"
+        "id": "qvPS3xbk9JBK",
+        "outputId": "999851d2-5a61-4768-8a43-1b1862ffb0bd",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Square it\n",
-        "tf.square(H)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(9,), dtype=int64, numpy=array([ 1,  4,  9, 16, 25, 36, 49, 64, 81])>"
             ]
           },
+          "execution_count": 73,
           "metadata": {
             "tags": []
           },
-          "execution_count": 73
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Square it\n",
+        "tf.square(H)"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "SJibI0GO9uf4",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 275
         },
-        "outputId": "0a50bff8-6654-470c-dad8-7177cdf29d7b"
+        "id": "SJibI0GO9uf4",
+        "outputId": "0a50bff8-6654-470c-dad8-7177cdf29d7b",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Find the squareroot (will error), needs to be non-integer\n",
-        "tf.sqrt(H)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "error",
           "ename": "InvalidArgumentError",
           "evalue": "ignored",
+          "output_type": "error",
           "traceback": [
             "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
             "\u001b[0;31mInvalidArgumentError\u001b[0m                      Traceback (most recent call last)",
@@ -3076,55 +3274,60 @@
             "\u001b[0;31mInvalidArgumentError\u001b[0m: Value for attr 'T' of int64 is not in the list of allowed values: bfloat16, half, float, double, complex64, complex128\n\t; NodeDef: {{node Sqrt}}; Op<name=Sqrt; signature=x:T -> y:T; attr=T:type,allowed=[DT_BFLOAT16, DT_HALF, DT_FLOAT, DT_DOUBLE, DT_COMPLEX64, DT_COMPLEX128]> [Op:Sqrt]"
           ]
         }
+      ],
+      "source": [
+        "# Find the squareroot (will error), needs to be non-integer\n",
+        "tf.sqrt(H)"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "zlxRWy6Q-NHK",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "f61c7c31-34da-4c8f-8040-be761e939f95"
+        "id": "zlxRWy6Q-NHK",
+        "outputId": "f61c7c31-34da-4c8f-8040-be761e939f95",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Change H to float32\n",
-        "H = tf.cast(H, dtype=tf.float32)\n",
-        "H"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(9,), dtype=float32, numpy=array([1., 2., 3., 4., 5., 6., 7., 8., 9.], dtype=float32)>"
             ]
           },
+          "execution_count": 75,
           "metadata": {
             "tags": []
           },
-          "execution_count": 75
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Change H to float32\n",
+        "H = tf.cast(H, dtype=tf.float32)\n",
+        "H"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "S73eO0p--TtN",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "6ae3c553-1df5-4f5a-a5a1-e3597300c583"
+        "id": "S73eO0p--TtN",
+        "outputId": "6ae3c553-1df5-4f5a-a5a1-e3597300c583",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Find the square root\n",
-        "tf.sqrt(H)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(9,), dtype=float32, numpy=\n",
@@ -3132,30 +3335,33 @@
               "       2.6457512, 2.828427 , 3.       ], dtype=float32)>"
             ]
           },
+          "execution_count": 76,
           "metadata": {
             "tags": []
           },
-          "execution_count": 76
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Find the square root\n",
+        "tf.sqrt(H)"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "RyCo55vz9u4f",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "3a8f9f11-4a00-482b-dde5-b5cebee8dcde"
+        "id": "RyCo55vz9u4f",
+        "outputId": "3a8f9f11-4a00-482b-dde5-b5cebee8dcde",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Find the log (input also needs to be float)\n",
-        "tf.math.log(H)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(9,), dtype=float32, numpy=\n",
@@ -3163,11 +3369,16 @@
               "       1.9459102, 2.0794415, 2.1972246], dtype=float32)>"
             ]
           },
+          "execution_count": 77,
           "metadata": {
             "tags": []
           },
-          "execution_count": 77
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Find the log (input also needs to be float)\n",
+        "tf.math.log(H)"
       ]
     },
     {
@@ -3186,148 +3397,163 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "tV7_uzdR_F4c",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "dbe2bd14-249b-4bf0-c2f1-1af02d98c59a"
+        "id": "tV7_uzdR_F4c",
+        "outputId": "dbe2bd14-249b-4bf0-c2f1-1af02d98c59a",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Create a variable tensor\n",
-        "I = tf.Variable(np.arange(0, 5))\n",
-        "I"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Variable 'Variable:0' shape=(5,) dtype=int64, numpy=array([0, 1, 2, 3, 4])>"
             ]
           },
+          "execution_count": 78,
           "metadata": {
             "tags": []
           },
-          "execution_count": 78
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Create a variable tensor\n",
+        "I = tf.Variable(np.arange(0, 5))\n",
+        "I"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "ukatOuCG_4CY",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "a6351712-d894-4e23-c57e-2ab45537d566"
+        "id": "ukatOuCG_4CY",
+        "outputId": "a6351712-d894-4e23-c57e-2ab45537d566",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Assign the final value a new value of 50\n",
-        "I.assign([0, 1, 2, 3, 50])"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Variable 'UnreadVariable' shape=(5,) dtype=int64, numpy=array([ 0,  1,  2,  3, 50])>"
             ]
           },
+          "execution_count": 79,
           "metadata": {
             "tags": []
           },
-          "execution_count": 79
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Assign the final value a new value of 50\n",
+        "I.assign([0, 1, 2, 3, 50])"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "3r2Pya_vAnLz",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "a65b7db9-a0ec-47d7-f3cf-12cb60eb31ac"
+        "id": "3r2Pya_vAnLz",
+        "outputId": "a65b7db9-a0ec-47d7-f3cf-12cb60eb31ac",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# The change happens in place (the last value is now 50, not 4)\n",
-        "I"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Variable 'Variable:0' shape=(5,) dtype=int64, numpy=array([ 0,  1,  2,  3, 50])>"
             ]
           },
+          "execution_count": 80,
           "metadata": {
             "tags": []
           },
-          "execution_count": 80
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# The change happens in place (the last value is now 50, not 4)\n",
+        "I"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "gZie_FduAo5O",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "0b7d34bf-76e9-429e-ecec-7bb2beedb750"
+        "id": "gZie_FduAo5O",
+        "outputId": "0b7d34bf-76e9-429e-ecec-7bb2beedb750",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Add 10 to every element in I\n",
-        "I.assign_add([10, 10, 10, 10, 10])"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Variable 'UnreadVariable' shape=(5,) dtype=int64, numpy=array([10, 11, 12, 13, 60])>"
             ]
           },
+          "execution_count": 81,
           "metadata": {
             "tags": []
           },
-          "execution_count": 81
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Add 10 to every element in I\n",
+        "I.assign_add([10, 10, 10, 10, 10])"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "2qXODgVOBDzC",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "5fd97dbb-eb43-4e55-b74a-f4e94956b4c2"
+        "id": "2qXODgVOBDzC",
+        "outputId": "5fd97dbb-eb43-4e55-b74a-f4e94956b4c2",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Again, the change happens in place\n",
-        "I"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Variable 'Variable:0' shape=(5,) dtype=int64, numpy=array([10, 11, 12, 13, 60])>"
             ]
           },
+          "execution_count": 82,
           "metadata": {
             "tags": []
           },
-          "execution_count": 82
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Again, the change happens in place\n",
+        "I"
       ]
     },
     {
@@ -3350,90 +3576,99 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "HLHrij0vBywD",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "83109e2d-e3be-4e95-e6dd-d84713e9dc70"
+        "id": "HLHrij0vBywD",
+        "outputId": "83109e2d-e3be-4e95-e6dd-d84713e9dc70",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Create a tensor from a NumPy array\n",
-        "J = tf.constant(np.array([3., 7., 10.]))\n",
-        "J"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(3,), dtype=float64, numpy=array([ 3.,  7., 10.])>"
             ]
           },
+          "execution_count": 83,
           "metadata": {
             "tags": []
           },
-          "execution_count": 83
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Create a tensor from a NumPy array\n",
+        "J = tf.constant(np.array([3., 7., 10.]))\n",
+        "J"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "P0KBe_FqCKdU",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "c4de5d97-8095-4e0c-86de-67fad637d88d"
+        "id": "P0KBe_FqCKdU",
+        "outputId": "c4de5d97-8095-4e0c-86de-67fad637d88d",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "(array([ 3.,  7., 10.]), numpy.ndarray)"
+            ]
+          },
+          "execution_count": 84,
+          "metadata": {
+            "tags": []
+          },
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "# Convert tensor J to NumPy with np.array()\n",
         "np.array(J), type(np.array(J))"
-      ],
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "(array([ 3.,  7., 10.]), numpy.ndarray)"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 84
-        }
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "xxKsJPvSCUPI",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "39cef6d1-2deb-4ec2-cbdf-b9e6f3b06488"
+        "id": "xxKsJPvSCUPI",
+        "outputId": "39cef6d1-2deb-4ec2-cbdf-b9e6f3b06488",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Convert tensor J to NumPy with .numpy()\n",
-        "J.numpy(), type(J.numpy())"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "(array([ 3.,  7., 10.]), numpy.ndarray)"
             ]
           },
+          "execution_count": 85,
           "metadata": {
             "tags": []
           },
-          "execution_count": 85
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Convert tensor J to NumPy with .numpy()\n",
+        "J.numpy(), type(J.numpy())"
       ]
     },
     {
@@ -3449,33 +3684,36 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "HrQoUeyPCXU9",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "d4790fab-fc39-41d8-bf6b-c628d0f1ada0"
+        "id": "HrQoUeyPCXU9",
+        "outputId": "d4790fab-fc39-41d8-bf6b-c628d0f1ada0",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "# Create a tensor from NumPy and from an array\n",
-        "numpy_J = tf.constant(np.array([3., 7., 10.])) # will be float64 (due to NumPy)\n",
-        "tensor_J = tf.constant([3., 7., 10.]) # will be float32 (due to being TensorFlow default)\n",
-        "numpy_J.dtype, tensor_J.dtype"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "(tf.float64, tf.float32)"
             ]
           },
+          "execution_count": 86,
           "metadata": {
             "tags": []
           },
-          "execution_count": 86
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Create a tensor from NumPy and from an array\n",
+        "numpy_J = tf.constant(np.array([3., 7., 10.])) # will be float64 (due to NumPy)\n",
+        "tensor_J = tf.constant([3., 7., 10.]) # will be float32 (due to being TensorFlow default)\n",
+        "numpy_J.dtype, tensor_J.dtype"
       ]
     },
     {
@@ -3499,13 +3737,31 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "URzFiwPoFDI7",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "a6c7bbe3-4bfb-499a-91e9-f8bd4313b6a0"
+        "id": "URzFiwPoFDI7",
+        "outputId": "a6c7bbe3-4bfb-499a-91e9-f8bd4313b6a0",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "<tf.Tensor: shape=(10,), dtype=int64, numpy=array([ 10,  12,  16,  22,  30,  40,  52,  66,  82, 100])>"
+            ]
+          },
+          "execution_count": 87,
+          "metadata": {
+            "tags": []
+          },
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "# Create a simple function\n",
         "def function(x, y):\n",
@@ -3514,32 +3770,35 @@
         "x = tf.constant(np.arange(0, 10))\n",
         "y = tf.constant(np.arange(10, 20))\n",
         "function(x, y)"
-      ],
+      ]
+    },
+    {
+      "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "EHGbvlkXF7Gs",
+        "outputId": "40f5d83c-f2fc-4c50-fdfe-f37b3fdfa75b",
+        "vscode": {
+          "languageId": "python"
+        }
+      },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tf.Tensor: shape=(10,), dtype=int64, numpy=array([ 10,  12,  16,  22,  30,  40,  52,  66,  82, 100])>"
             ]
           },
+          "execution_count": 88,
           "metadata": {
             "tags": []
           },
-          "execution_count": 87
+          "output_type": "execute_result"
         }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "EHGbvlkXF7Gs",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "40f5d83c-f2fc-4c50-fdfe-f37b3fdfa75b"
-      },
+      ],
       "source": [
         "# Create the same function and decorate it with tf.function\n",
         "@tf.function\n",
@@ -3547,21 +3806,6 @@
         "  return x ** 2 + y\n",
         "\n",
         "tf_function(x, y)"
-      ],
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "<tf.Tensor: shape=(10,), dtype=int64, numpy=array([ 10,  12,  16,  22,  30,  40,  52,  66,  82, 100])>"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 88
-        }
       ]
     },
     {
@@ -3592,25 +3836,28 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "3rFNSeODxi3L",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "7dd6e024-bed3-46ad-d96f-bea634317e24"
+        "id": "3rFNSeODxi3L",
+        "outputId": "7dd6e024-bed3-46ad-d96f-bea634317e24",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "print(tf.config.list_physical_devices('GPU'))"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "[PhysicalDevice(name='/physical_device:GPU:0', device_type='GPU')]\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "print(tf.config.list_physical_devices('GPU'))"
       ]
     },
     {
@@ -3628,26 +3875,29 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "iAvMwRbZyULE",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "eaab2fea-5960-43f1-899f-1eee870a76f9"
+        "id": "iAvMwRbZyULE",
+        "outputId": "eaab2fea-5960-43f1-899f-1eee870a76f9",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "import tensorflow as tf\n",
-        "print(tf.config.list_physical_devices('GPU'))"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "[PhysicalDevice(name='/physical_device:GPU:0', device_type='GPU')]\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "import tensorflow as tf\n",
+        "print(tf.config.list_physical_devices('GPU'))"
       ]
     },
     {
@@ -3665,19 +3915,20 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "yOuVvG5kyefS",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "fc734522-6270-447d-cefc-34e9fbe4a89b"
+        "id": "yOuVvG5kyefS",
+        "outputId": "fc734522-6270-447d-cefc-34e9fbe4a89b",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "!nvidia-smi"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "Mon Mar 15 22:33:50 2021       \n",
@@ -3699,9 +3950,11 @@
             "|        ID   ID                                                   Usage      |\n",
             "|=============================================================================|\n",
             "+-----------------------------------------------------------------------------+\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "!nvidia-smi"
       ]
     },
     {
@@ -3749,5 +4002,23 @@
         "* Watch the video [\"What's a tensor?\"](https://www.youtube.com/watch?v=f5liqUk0ZTw) - a great visual introduction to many of the concepts we've covered in this notebook."
       ]
     }
-  ]
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "authorship_tag": "ABX9TyMHAtaiFyROOAD0GJ9ufhOp",
+      "collapsed_sections": [
+        "fzjcZ4FHCOb5"
+      ],
+      "include_colab_link": true,
+      "name": "00_tensorflow_fundamentals.ipynb",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }


### PR DESCRIPTION
`reduce_std()`, tf.reduce_variance` function was deprecated in TensorFlow 2.4 and later versions and has been replaced by the `tf.math.reduce_std()` and `tf.math.reduce_variance` function.