### PR TITLE
The predict function must take X_test not y_test

### DIFF
--- a/02_neural_network_classification_in_tensorflow.ipynb
+++ b/02_neural_network_classification_in_tensorflow.ipynb
@@ -1798,7 +1798,7 @@
       },
       "source": [
         "# Make predictions with our trained model\n",
-        "y_reg_preds = model_3.predict(y_reg_test)\n",
+        "y_reg_preds = model_3.predict(X_reg_test)\n",
         "\n",
         "# Plot the model's predictions against our regression data\n",
         "plt.figure(figsize=(10, 7))\n",


### PR DESCRIPTION
By mistake, the code says model.predict(y_test) while it should say model.predict(X_test) because the predict function takes the X_test data to output y_preds to be later compared to y_test and measure the accuracy of the model.