### PR TITLE
Update function make_confusion_metrix to have vertical xticklables

### DIFF
--- a/extras/helper_functions.py
+++ b/extras/helper_functions.py
@@ -81,13 +81,13 @@ def make_confusion_matrix(y_true, y_pred, classes=None, figsize=(10, 10), text_s
          xlabel="Predicted label",
          ylabel="True label",
          xticks=np.arange(n_classes), # create enough axis slots for each class
-         yticks=np.arange(n_classes), 
-         xticklabels=labels, # axes will labeled with class names (if they exist) or ints
+         xticklabels=labels,
          yticklabels=labels)
   
   # Make x-axis labels appear on bottom
   ax.xaxis.set_label_position("bottom")
   ax.xaxis.tick_bottom()
+  ax.set_xticklabels(labels, rotation=90) # axes will labeled with class names (if they exist) or ints
 
   # Set the threshold for different colors
   threshold = (cm.max() + cm.min()) / 2.


### PR DESCRIPTION
Thank you much for guiding through the Tensorflow course very systematically. I have learned a good deal.

I found the 'make_confusion_matrix' function very useful.

here is the scenario:


`y_true = ["countryman rambo", "neighboring man jumbo", "countryman rambo", "countryman rambo", "neighboring man jumbo", "birdman", "superman", "logicalman"]
y_pred = ["neighboring man jumbo", "neighboring man jumbo", "countryman rambo", "countryman rambo", "neighboring man jumbo", "countryman rambo", "superman", "logicalman"]
labels = ["countryman rambo", "neighboring man jumbo", "birdman", "superman", "logicalman"]

make_confusion_matrix_old(
    y_true,
    y_pred,
    labels,
    figsize=(8, 8),
)` 

<img width="813" alt="image" src="https://github.com/user-attachments/assets/36c813e8-f3aa-4ace-8fb2-c8de5adac705">

when the confusion matrix comes out nicely but the Xlabes needs some help.

I have updated the code and here is the new version.

<img width="809" alt="image" src="https://github.com/user-attachments/assets/24ba26bc-7524-43d0-ba63-4ee092315fbc">


Thanks,

Jaydip