### PR TITLE
Update 01_neural_network_regression_in_tensorflow.ipynb

### DIFF
--- a/01_neural_network_regression_in_tensorflow.ipynb
+++ b/01_neural_network_regression_in_tensorflow.ipynb
@@ -583,7 +583,7 @@
       },
       "source": [
         "# Make a prediction with the model\n",
-        "model.predict([17.0])"
+        "model.predict(np.array([17.0]))"
       ],
       "execution_count": 10,
       "outputs": [
@@ -945,7 +945,7 @@
       },
       "source": [
         "# Try and predict what y would be if X was 17.0\n",
-        "model.predict([17.0]) # the right answer is 27.0 (y = X + 10)"
+        "model.predict(np.array([17.0])) # the right answer is 27.0 (y = X + 10)"
       ],
       "execution_count": 13,
       "outputs": [


### PR DESCRIPTION
Made changes to function model.predict(). In version 2.17, the execution of model.predict([17.0]) gives error "Unrecognized data type: x=[17.0] (of type <class 'list'>)". This can be fixed by converting [17.0] into a Numpy array, therefore replacing model.predict([17.0])  with model.predict(np.array([17.0])) .In TensorFlow 2.12, lists were accepted as input to model.predict, but in TensorFlow 2.17, the function expects input data to be explicitly converted into NumPy arrays or tensors